### PR TITLE
Address issue regarding attachment of instance profile to EB environment

### DIFF
--- a/MigrateIISWebsiteToElasticBeanstalk.ps1
+++ b/MigrateIISWebsiteToElasticBeanstalk.ps1
@@ -2705,10 +2705,9 @@ Invoke-CommandsWithRetry 99 $MigrationRunLogFile {
         $ebStkName = $solutionStack
     }
     New-Message $InfoMsg "Creating a new Elastic Beanstalk environment using solution stack '$ebStkName'…" $MigrationRunLogFile
-    $instanceProfile = New-Object Amazon.ElasticBeanstalk.Model.ConfigurationOptionSetting -ArgumentList aws:autoscaling:launchconfiguration,IamInstanceProfile,aws-elasticbeanstalk-ec2-role
-    $instanceProfile.OptionName = "InstanceType"
-    $instanceProfile.Value = $instanceType
-    New-EBEnvironment -ApplicationName $glb_ebAppName -EnvironmentName $MigrationRunId -SolutionStackName $ebStkName -OptionSetting $instanceProfile -Tag $EBTag
+    $instanceProfileOptionSetting = New-Object Amazon.ElasticBeanstalk.Model.ConfigurationOptionSetting -ArgumentList aws:autoscaling:launchconfiguration,IamInstanceProfile,aws-elasticbeanstalk-ec2-role
+    $instanceTypeOptionSetting = New-Object Amazon.ElasticBeanstalk.Model.ConfigurationOptionSetting -ArgumentList aws:autoscaling:launchconfiguration,InstanceType,$instanceType
+    New-EBEnvironment -ApplicationName $glb_ebAppName -EnvironmentName $MigrationRunId -SolutionStackName $ebStkName -OptionSetting $instanceProfileOptionSetting,$instanceTypeOptionSetting -Tag $EBTag
 }
 
 $versionLabel = $MigrationRunId + "-vl"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There used to be an issue attaching the default Elastic Beanstalk instance profile (aws-elasticbeanstalk-ec2-role) to newly created environments. This led to complications using EB features such as managed updates. The root cause of this issue was the fact that the instance profile ConfigurationOptionSetting object was being overwritten by the values for instance type. This pull request addresses this issue by creating multiple ConfigurationOptionSetting objects and passing them as a list to the New-EBEnvironment request. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
