### PR TITLE
Change for straight double quote marks

### DIFF
--- a/MigrateIISWebsiteToElasticBeanstalk.ps1
+++ b/MigrateIISWebsiteToElasticBeanstalk.ps1
@@ -48,9 +48,9 @@ $Global:mfarg_userInputConnectionStringNum = $ConnectionStringIndex
 $Global:mfarg_userInputEnvironmentTypeNum = $EnvironmentType
 
 $Global:mfarg_userconsent = $False
-$Global:mfarg_userinputI = “NonInteractiveMode”
-$Global:mfarg_userinputY = “Y”
-$Global:mfarg_userinputK = “K”
+$Global:mfarg_userinputI = "NonInteractiveMode"
+$Global:mfarg_userinputY = "Y"
+$Global:mfarg_userinputK = "K"
 
 
 #Requires -RunAsAdministrator


### PR DESCRIPTION
Changed the opening double quote marks for straight double quote marks. These cause issues on Windows machines. I received the error: " The term 'â€œYâ€' is not recognized as the name of a cmdlet, function,"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
