### PR TITLE
Update MigrateIISWebsiteToElasticBeanstalk.ps1

### DIFF
--- a/MigrateIISWebsiteToElasticBeanstalk.ps1
+++ b/MigrateIISWebsiteToElasticBeanstalk.ps1
@@ -2065,7 +2065,7 @@ function Global:Verify-UserHasRequiredAWSPolicies {
         .SYNOPSIS
             This function verifies that the current AWS user has the following AWS managed policies:
                 1. IAMReadOnlyAccess (only needed for Get-IAMAttachedUserPolicyList)
-                2. AWSElasticBeanstalkFullAccess (needed for EB application deployment operations)
+                2. AdministratorAccess-AWSElasticBeanstalk (needed for EB application deployment operations)
         .INPUTS
             None
         .OUTPUTS
@@ -2081,11 +2081,11 @@ function Global:Verify-UserHasRequiredAWSPolicies {
     }
 
     foreach ($policy in $policies) {
-        if ($policy.PolicyName -eq "AWSElasticBeanstalkFullAccess") {
+        if ($policy.PolicyName -eq "AdministratorAccess-AWSElasticBeanstalk") {
             return
         }
     }
-    throw "ERROR: Please make sure that the AWS managed policy AWSElasticBeanstalkFullAccess is attached to the current user"    
+    throw "ERROR: Please make sure that the AWS managed policy AdministratorAccess-AWSElasticBeanstalk is attached to the current user"    
 }
 
 function Global:Verify-RequiredRolesExist {


### PR DESCRIPTION
AWSElasticBeanstalkFullAccess policy has been retired and replaced with AdministratorAccess-AWSElasticBeanstalk

*Issue #, if available:*

*Description of changes:* Replaced AWSElasticBeanstalkFullAccess with the new policy AdministratorAccess-AWSElasticBeanstalk
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.managed-policies.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
