### PR TITLE
adding Cloudformation Stack to use the Console to migrate the appliation

### DIFF
--- a/cfn_stack/WWAMALab.yml
+++ b/cfn_stack/WWAMALab.yml
@@ -1,0 +1,37 @@
+Resources:
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-048fb16ca78a503fe
+      InstanceType: t3.medium
+      Tags:
+        - Key: Name
+          Value: "WWAMA Lab"
+      SecurityGroups:
+        - !Ref MySecurityGroup
+      KeyName:
+        Ref: "KeyPair"
+      UserData:
+        !Base64 |
+          <powershell>
+          (new-object net.webclient).DownloadFile('https://github.com/awslabs/windows-web-app-migration-assistant/archive/master.zip','c:\wwama.zip')
+          </powershell>
+  MySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: SimpleWinGroup
+      GroupDescription: Enable RDP traffic via port 3389
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3389
+          ToPort: 3389
+          CidrIp: 0.0.0.0/0
+Parameters:
+  KeyPair:
+    Description: Key Pair for this Instance
+    Type: "AWS::EC2::KeyPair::KeyName"
+Outputs:
+  ServerDns:
+    Value: !GetAtt
+      - Ec2Instance
+      - PublicDnsName


### PR DESCRIPTION
*Description of changes:*
This file supports the tutorial https://aws.amazon.com/getting-started/hands-on/migrate-aspnet-web-application-elastic-beanstalk/. Specifically, it makes it help users define a CloudFormation stack that will launch the Windows EC2 instance that is used throughout the tutorial. Using this file in Step 2a will launch the small instance necessary and then import the Windows Web Application Migration Assistant (WWAMA) to migrate an ASP.NET app. 

Users can also take this file, edit and adapt to their needs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
